### PR TITLE
Add content coach plugin for Claude Code and Desktop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,28 @@
       },
       "category": "wordpress",
       "tags": ["wordpress", "themes", "block-themes", "studio"]
+    },
+    {
+      "name": "content-coach-code",
+      "source": "./claude-code/content-coach",
+      "description": "AI-powered content reviewer that analyzes WordPress posts across four pillars and delivers actionable feedback as block notes directly in the editor.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Automattic"
+      },
+      "category": "wordpress",
+      "tags": ["wordpress", "content", "review", "accessibility", "seo", "block-notes"]
+    },
+    {
+      "name": "content-coach",
+      "source": "./claude-cowork/content-coach",
+      "description": "AI-powered content reviewer that analyzes WordPress posts across four pillars and delivers actionable feedback as block notes directly in the editor.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Automattic"
+      },
+      "category": "wordpress",
+      "tags": ["wordpress", "content", "review", "accessibility", "seo", "block-notes"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,7 +41,7 @@
       "tags": ["wordpress", "content", "review", "accessibility", "seo", "block-notes"]
     },
     {
-      "name": "content-coach",
+      "name": "content-coach-cowork",
       "source": "./claude-cowork/content-coach",
       "description": "AI-powered content reviewer that analyzes WordPress posts across four pillars and delivers actionable feedback as block notes directly in the editor.",
       "version": "0.1.0",

--- a/claude-code/content-coach/.claude-plugin/plugin.json
+++ b/claude-code/content-coach/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "content-coach",
+  "name": "content-coach-code",
   "version": "0.1.0",
   "description": "AI-powered content reviewer that analyzes WordPress posts across four pillars — readability, search visibility, content guidelines, and media accessibility — and delivers actionable feedback as block notes directly in the editor.",
   "author": {

--- a/claude-code/content-coach/.claude-plugin/plugin.json
+++ b/claude-code/content-coach/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "content-coach",
+  "version": "0.1.0",
+  "description": "AI-powered content reviewer that analyzes WordPress posts across four pillars — readability, search visibility, content guidelines, and media accessibility — and delivers actionable feedback as block notes directly in the editor.",
+  "author": {
+    "name": "Automattic"
+  }
+}

--- a/claude-code/content-coach/CONNECTORS.md
+++ b/claude-code/content-coach/CONNECTORS.md
@@ -1,0 +1,100 @@
+# Connectors
+
+## Required: WordPress.com MCP Server
+
+This plugin requires the `mcp__wpcom-custom__wpcom-mcp-content-authoring` tool from the `wpcom-custom` MCP server. It provides both content fetching and block notes operations via the STRAP pattern (Single Tool, Resource.Action, Params).
+
+The `wpcom-custom` server is configured in `.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "wpcom-custom": {
+      "type": "http",
+      "url": "https://public-api.wordpress.com/wpcom/v2/mcp/v1"
+    }
+  }
+}
+```
+
+### Operations Used
+
+| Operation | Purpose |
+|---|---|
+| `posts.get` | Fetch post content (title, raw block markup, rendered HTML) with `context=edit` |
+| `block-notes.list` | List blocks with their noteIds, and existing notes as threaded trees |
+| `block-notes.create` | Create a new note on a block (with `block_index` to associate it) |
+| `block-notes.reply` | Reply to an existing note thread on a block |
+
+### STRAP Actions
+
+- **`list`** — Discover all available operations
+- **`describe`** — Get the parameter schema for a specific operation
+- **`execute`** — Run an operation with params
+
+### Tool Call Examples
+
+**List notes and block map (read-only, no confirmation needed):**
+```json
+{
+  "wpcom_site": "yoursite.wordpress.com",
+  "action": "execute",
+  "operation": "block-notes.list",
+  "params": {
+    "post_id": 123
+  }
+}
+```
+
+**Create a note (mutative — requires `user_confirmed`):**
+```json
+{
+  "wpcom_site": "yoursite.wordpress.com",
+  "action": "execute",
+  "operation": "block-notes.create",
+  "params": {
+    "post_id": 123,
+    "content": "Consider splitting this sentence for readability.",
+    "block_index": 2,
+    "user_confirmed": "yes"
+  }
+}
+```
+
+**Reply to a note (mutative — requires `user_confirmed`):**
+```json
+{
+  "wpcom_site": "yoursite.wordpress.com",
+  "action": "execute",
+  "operation": "block-notes.reply",
+  "params": {
+    "post_id": 123,
+    "parent_id": 456,
+    "content": "This has been addressed.",
+    "user_confirmed": "yes"
+  }
+}
+```
+
+### Safety Policy
+
+The content-authoring tool enforces a safety policy on mutative operations (create, reply). You must:
+1. Describe what you plan to do to the user
+2. Get their confirmation
+3. Include `user_confirmed` with their response in `params`
+
+Read-only operations (`block-notes.list`, `posts.get`) are exempt.
+
+### Setup
+
+Ensure `wpcom-custom` MCP server is configured in your `.mcp.json` and authenticated.
+
+## Self-Contained Capabilities
+
+These features do not require external services:
+
+| Capability | Implementation |
+|---|---|
+| Readability analysis | Claude's language analysis |
+| SEO evaluation | Claude's knowledge of search best practices |
+| Content guidelines checks | Pattern matching against skill rules |
+| Media accessibility review | Block markup inspection |

--- a/claude-code/content-coach/README.md
+++ b/claude-code/content-coach/README.md
@@ -1,0 +1,75 @@
+# Content Coach Plugin
+
+An AI-powered content reviewer that analyzes WordPress posts and delivers actionable feedback as block notes directly in the editor.
+
+## Requirements
+
+- A WordPress.com site with the block notes feature enabled
+- The WordPress.com MCP server with `wpcom-mcp-content-authoring` enabled
+
+## Setup
+
+### Claude Code
+
+Install from the marketplace:
+
+```bash
+claude plugin install content-coach-code
+```
+
+Or load directly from the directory:
+
+```bash
+claude --plugin-dir ./claude-code/content-coach
+```
+
+### MCP Server
+
+Add the WordPress.com MCP server to your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "wpcom-custom": {
+      "type": "http",
+      "url": "https://public-api.wordpress.com/wpcom/v2/mcp/v1"
+    }
+  }
+}
+```
+
+## Usage
+
+```
+/review-content <post-id>
+```
+
+Claude will:
+1. Fetch the post content and block map in parallel
+2. Analyze content across four quality pillars
+3. Ask for your confirmation before leaving notes
+4. Leave 3–8 concise, actionable block notes in the editor
+5. Summarize the findings in chat
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/review-content` | Review a WordPress post across four quality pillars and leave feedback as block notes |
+
+## Skills
+
+| Skill | What It Checks |
+|---|---|
+| `readability` | Sentence/paragraph length, passive voice, word complexity, heading clarity |
+| `search-visibility` | Title/H1, heading hierarchy, meta descriptions, internal links, URL slugs |
+| `content-guidelines` | Tone consistency, point of view, filler language, unsourced claims |
+| `media-accessibility` | Alt text, link text, heading structure, content accessibility |
+
+## How It Works
+
+1. Run `/review-content <post-id>`
+2. The plugin fetches the post content via `posts.get` and the block map + notes via `block-notes.list` — both through the `wpcom-mcp-content-authoring` tool
+3. Claude analyzes the content across all four pillars using the skill knowledge bases
+4. After showing you a summary and getting your confirmation, feedback is delivered as block notes
+5. The author sees the notes in the WordPress editor, highlighted on the relevant blocks

--- a/claude-code/content-coach/commands/review-content.md
+++ b/claude-code/content-coach/commands/review-content.md
@@ -1,6 +1,6 @@
 ---
 description: Review a WordPress post and leave actionable feedback as block notes
-argument-hint: "<post ID>"
+argument-hint: "<post ID> [site URL]"
 ---
 
 # Review Content
@@ -11,9 +11,17 @@ Review a WordPress post across four quality pillars and deliver feedback as bloc
 
 ## Trigger
 
-User runs `/review-content` with a post ID, or asks to review/coach/check a WordPress post.
+User runs `/review-content` with a post ID (and optionally a site URL), or asks to review/coach/check a WordPress post.
 
 ## Workflow
+
+### Step 0: Resolve the Site
+
+Every MCP call requires a `wpcom_site` parameter. Determine the site using the first match:
+
+1. **Provided in the command** — e.g. `/review-content 123 mysite.wordpress.com`
+2. **Known from conversation context** — the user mentioned or used a site earlier
+3. **Ask the user** — if neither of the above, ask which site the post belongs to
 
 ### Step 1: Fetch Content and Notes
 

--- a/claude-code/content-coach/commands/review-content.md
+++ b/claude-code/content-coach/commands/review-content.md
@@ -1,0 +1,102 @@
+---
+description: Review a WordPress post and leave actionable feedback as block notes
+argument-hint: "<post ID>"
+---
+
+# Review Content
+
+> This command uses the `readability`, `search-visibility`, `content-guidelines`, and `media-accessibility` skills.
+
+Review a WordPress post across four quality pillars and deliver feedback as block notes that appear directly in the editor.
+
+## Trigger
+
+User runs `/review-content` with a post ID, or asks to review/coach/check a WordPress post.
+
+## Workflow
+
+### Step 1: Fetch Content and Notes
+
+Make these two calls in parallel using `mcp__wpcom-custom__wpcom-mcp-content-authoring`:
+
+1. **`posts.get`** with `context=edit` — returns the post content (title, raw block markup, rendered HTML) for analysis.
+2. **`block-notes.list`** with `post_id` — returns:
+   - A **block map** showing each top-level block's index, type, noteId, and content preview
+   - All existing **notes** as threaded trees
+
+From these two responses you have everything needed: the content to review and the note state of every block.
+
+- If notes already exist, read them. Do not duplicate feedback that's already been given.
+- If a previous note raised an issue that hasn't been addressed, you may reply to that thread — but don't repeat the same point.
+
+### Step 2: Analyze the Content
+
+Work through each pillar systematically. Identify the **highest-impact issues only** — do not flag everything. A useful review has 3–8 notes total, not 20.
+
+#### Pillar 1: Readability
+Apply the `readability` skill. Focus on:
+- Sentences over 25 words
+- Paragraphs over 4 sentences
+- Passive voice (only the most impactful instances)
+- Jargon with simpler alternatives
+
+#### Pillar 2: Search Visibility
+Apply the `search-visibility` skill. Focus on:
+- Title/H1 issues (missing, too long, generic)
+- Heading hierarchy problems (skipped levels)
+- Missing internal links
+- Slug quality
+
+#### Pillar 3: Content Guidelines
+Apply the `content-guidelines` skill. Focus on:
+- Tone inconsistencies (the biggest shifts only)
+- Unsubstantiated claims
+- Filler language (only the most egregious)
+
+#### Pillar 4: Media & Accessibility
+Apply the `media-accessibility` skill. Focus on:
+- Missing alt text on images (highest priority)
+- Poor link text ("click here")
+- Missing headings in long content
+
+### Step 3: Ask for Confirmation
+
+Before leaving any notes, tell the user:
+- How many notes you plan to leave
+- A brief summary of the issues found across each pillar
+
+Wait for the user to confirm before proceeding. Their confirmation response will be used as the `user_confirmed` value for each note operation.
+
+### Step 4: Leave Notes
+
+After the user confirms, leave the notes. For each issue:
+
+1. **Determine which block** the feedback applies to using the block map from Step 1.
+
+2. **Choose the right operation** on `mcp__wpcom-custom__wpcom-mcp-content-authoring`:
+   - Block has a `noteId` → use `block-notes.reply` with `parent_id` set to that noteId
+   - Block has no `noteId` → use `block-notes.create` with `block_index`
+
+3. **Include `user_confirmed`** in `params` with the user's confirmation response. This is required by the safety policy for all create/reply operations.
+
+4. **Write the note.** Follow these rules strictly:
+   - **50 words or fewer.** The block notes UI has limited space.
+   - **Do NOT mention block index, block type, or position.** The UI highlights the block — the reader knows which block it's on.
+   - **Be direct and actionable.** Say what to change and why. Don't describe what you observed.
+   - **Quote the specific text** when suggesting a rewrite.
+   - **One note per block.** If a block has multiple issues, combine the most important one into a single note.
+
+### Step 5: Summarize
+
+After leaving all notes, give the user a brief summary in chat (not as a block note):
+- How many notes you left
+- Which pillars had the most issues
+- The single most impactful change they could make
+
+## Constraints
+
+- **Do NOT edit the post content.** You are a reviewer, not an editor. Leave suggestions as notes.
+- **3–8 notes maximum** for a typical post. More than that overwhelms the author.
+- **Skip blocks that are fine.** Not every block needs a note. No news is good news.
+- **Don't be sycophantic.** Don't leave notes that say "Great paragraph!" — only leave notes that suggest improvements.
+- **Author name:** Use the default (authenticated user). Only pass `author_name` if the user requests a custom name.

--- a/claude-code/content-coach/skills/content-guidelines/SKILL.md
+++ b/claude-code/content-coach/skills/content-guidelines/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: content-guidelines
+description: Check content against brand voice, tone consistency, and editorial standards. Use when reviewing content for professionalism and brand alignment.
+---
+
+# Content Guidelines Skill
+
+Ensure content maintains a consistent, professional voice and follows editorial best practices. This skill covers what the author *says* and *how* they say it.
+
+## What to Check
+
+### Tone Consistency
+- The tone should be consistent throughout the entire post.
+- Flag abrupt shifts — e.g., casual opening ("Hey folks!") followed by formal body ("It is imperative to note...").
+- Common inconsistency: lyrical/creative introductions followed by dry, factual body copy. The reader expects the same voice throughout.
+- Note which tone the majority of the post uses, and flag the outlier sections.
+
+### Point of View
+- Flag inconsistent POV switches within a post.
+- "We recommend..." then "You should..." then "One might consider..." — pick one and stick with it.
+- Second person ("you") is usually best for instructional content.
+- First person plural ("we") works for company blogs.
+
+### Filler and Weak Language
+- Flag hedging words that weaken the message: "very", "really", "quite", "somewhat", "fairly", "rather", "just".
+- Flag empty intensifiers: "extremely important", "absolutely essential" — if it's important, show why.
+- Flag clichés: "at the end of the day", "it goes without saying", "in today's world", "game-changer".
+
+### Repetition
+- Flag the same word or phrase used repeatedly in close proximity.
+- Flag repeated sentence structures (three sentences in a row starting with "This...").
+- Suggest varied alternatives.
+
+### Accuracy and Claims
+- Flag unsubstantiated claims: "studies show", "research proves", "experts agree" — without a source or link.
+- Flag superlatives without evidence: "the best", "the fastest", "the most popular".
+- Suggest adding a source link or softening to "one of the best" if no source is available.
+
+### Formatting Consistency
+- Flag inconsistent list formatting (some items end with periods, others don't).
+- Flag inconsistent capitalization in headings (some title case, some sentence case).
+- Flag inconsistent use of bold/italic for emphasis.
+
+## How to Give Feedback
+
+- Don't lecture about writing rules. Just suggest the fix.
+- Quote the specific phrase and offer a rewrite.
+- Keep notes under 50 words.
+- Tone issues are sensitive — frame feedback as consistency, not criticism of the author's voice.
+
+## Examples of Good Notes
+
+> "Tone shifts here from casual ('super easy') to formal ('it is recommended'). Match the casual voice used in earlier paragraphs: 'we recommend' keeps it consistent."
+
+> "'Very unique' — unique is absolute, no modifier needed. Just 'unique' or find a more specific adjective."
+
+> "'Studies show this improves engagement.' Which studies? Add a link or soften to 'this can improve engagement.'"

--- a/claude-code/content-coach/skills/media-accessibility/SKILL.md
+++ b/claude-code/content-coach/skills/media-accessibility/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: media-accessibility
+description: Review images, media, and visual elements for accessibility compliance and quality. Use when checking alt text, captions, and media best practices.
+---
+
+# Media & Accessibility Skill
+
+Ensure all media elements are accessible, properly described, and enhance the content rather than just decorating it.
+
+## What to Check
+
+### Alt Text
+- Every image block MUST have alt text. Flag any `core/image` block with empty or missing alt.
+- Alt text should describe what the image *shows*, not what it *is*.
+  - Bad: "image1.jpg", "photo", "screenshot"
+  - Bad: "Image of a person" (too generic)
+  - Good: "A hiker standing at the edge of a cliff overlooking a valley at sunrise"
+- Decorative images (spacers, dividers, background textures) should have empty alt (`alt=""`), not missing alt. But in practice, most images in post content are not decorative.
+- Flag alt text that starts with "Image of..." or "Photo of..." — screen readers already announce it as an image.
+- Flag excessively long alt text (over 125 characters). Keep it concise.
+
+### Image Quality Signals
+- Flag images with generic file names: `IMG_4532.jpg`, `screenshot-2024.png`, `image.png`.
+- Suggest descriptive file names that match the content.
+- Flag if a post has no images at all — for most content types, at least one image improves engagement.
+
+### Captions
+- Captions are optional but valuable. They're among the most-read text on a page.
+- Don't flag missing captions as an error — suggest them as an enhancement for key images.
+- Flag captions that just repeat the alt text. They should add context the alt text doesn't provide.
+
+### Heading Accessibility
+- Headings should not be empty.
+- Heading blocks used purely for visual styling (making text big/bold) without semantic meaning is an accessibility issue.
+- Content should be readable in heading order — if you read just the headings top to bottom, they should outline the post.
+
+### Link Accessibility
+- Flag links with text like "click here", "read more", "this link", "here". Screen readers often navigate by link text alone.
+- Good link text describes the destination: "read our pricing guide" not "click here."
+- Flag links that open in new tabs without indicating it (though this is hard to detect from markup alone — note as a general guideline).
+
+### Color and Contrast
+- Cannot be checked from markup alone, but flag cases where the author relies on color to convey meaning (e.g., "the items in red are required").
+- Suggest adding text labels alongside color indicators.
+
+### Content Structure
+- Flag very long posts with no headings — screen reader users rely on headings to navigate.
+- Flag content that uses bold text as a pseudo-heading instead of proper heading blocks.
+
+## How to Give Feedback
+
+- Frame accessibility feedback as helping *all* readers, not just compliance.
+- Be specific: "Add alt text describing what this chart shows" not "missing alt text."
+- Keep notes under 50 words.
+- Prioritize: missing alt text > heading issues > link text > everything else.
+
+## Examples of Good Notes
+
+> "Missing alt text. Describe what this image shows — e.g., 'Bar chart comparing monthly sales for Q1 2024 across three product lines.'"
+
+> "Link text 'click here' doesn't describe the destination. Try: 'view our return policy' so it makes sense out of context."
+
+> "No headings in 800+ words of content. Add H2s to break this into scannable sections — readers and screen readers both benefit."

--- a/claude-code/content-coach/skills/readability/SKILL.md
+++ b/claude-code/content-coach/skills/readability/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: readability
+description: Analyze text readability and suggest improvements to sentence structure, paragraph length, word complexity, and voice. Use when reviewing content for reader experience.
+---
+
+# Readability Skill
+
+Evaluate and improve how easy content is to read and understand. Poor readability increases bounce rates and reduces engagement.
+
+## What to Check
+
+### Sentence Length
+- Flag sentences over 25 words. They're hard to parse on screens.
+- Suggest splitting or simplifying — don't just say "too long."
+- One idea per sentence. If a sentence uses "and" or "but" to join two independent thoughts, it should probably be two sentences.
+
+### Paragraph Length
+- Flag paragraphs over 4 sentences or ~80 words.
+- Web readers scan. Dense walls of text get skipped.
+- Suggest logical break points when recommending a split.
+
+### Passive Voice
+- Flag passive constructions ("was written by", "has been updated", "will be reviewed").
+- Suggest the active alternative: who does the action?
+- Exception: passive is fine when the actor is unknown or irrelevant ("The server was restarted at 3am").
+
+### Word Complexity
+- Flag jargon, technical terms, or uncommon words that have simpler alternatives.
+- "utilize" → "use", "commence" → "start", "facilitate" → "help", "leverage" → "use".
+- Exception: domain-specific terms that the target audience expects (don't simplify "API" for a developer audience).
+
+### Transition and Flow
+- Flag abrupt topic changes between consecutive blocks.
+- Look for missing transition words or phrases between paragraphs.
+- Each paragraph should connect logically to the previous one.
+
+### Heading Clarity
+- Headings should tell the reader what the section contains.
+- Flag vague headings like "Overview", "Introduction", "More Info".
+- Good headings are specific: "How to set up email forwarding" not "Email Setup".
+
+## How to Give Feedback
+
+- Be specific. Quote the problematic phrase and suggest a rewrite.
+- Keep notes under 50 words. The block notes UI is small.
+- Focus on the highest-impact issues first. Don't flag every long sentence — pick the worst ones.
+- If a block has multiple readability issues, combine them into one note with the most important fix.
+
+## Examples of Good Notes
+
+> "Consider splitting this into two sentences at 'however.' The current 32-word sentence is hard to follow on mobile."
+
+> "Passive voice: 'was created by the team' → 'the team created'. Makes the action clearer."
+
+> "This paragraph covers pricing, features, and support. Split at the support section for easier scanning."

--- a/claude-code/content-coach/skills/search-visibility/SKILL.md
+++ b/claude-code/content-coach/skills/search-visibility/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: search-visibility
+description: Evaluate on-page SEO factors and suggest improvements to help content get found in search. Use when reviewing content for search engine visibility.
+---
+
+# Search Visibility Skill
+
+Help content rank better in search results without requiring SEO expertise from the author. Focus on practical, high-impact improvements.
+
+## What to Check
+
+### Title / H1
+- The post should have exactly one H1 (usually the post title).
+- The H1 should include the primary topic/keyword naturally.
+- Flag if the H1 is missing, duplicated, or generic ("Untitled", "New Post").
+- Keep titles under 60 characters to avoid truncation in search results.
+
+### Heading Hierarchy
+- Headings should follow a logical order: H1 → H2 → H3. No skipping levels.
+- Flag H3 that appears before any H2, or H4 without a parent H3.
+- Headings help search engines understand content structure.
+
+### Meta Description (if available)
+- Should be 120–160 characters.
+- Should summarize the page content and include the primary topic.
+- Should be compelling — it's the "ad copy" in search results.
+- Flag if missing or if it's just the first sentence of the post repeated.
+
+### Internal Links
+- Flag posts with zero internal links. Every post should link to at least one other page on the site.
+- Links help search engines discover and understand related content.
+- Suggest specific linking opportunities based on the content topic.
+
+### URL / Slug
+- Slugs should be short, descriptive, and include the primary topic.
+- Flag slugs that are auto-generated gibberish, excessively long, or include dates/IDs unnecessarily.
+- Good: `/best-hiking-trails-colorado` Bad: `/post-12847` or `/2024/01/15/the-complete-and-comprehensive-guide-to-all-hiking-trails`
+
+### Image SEO
+- Images should have descriptive file names (not `IMG_4532.jpg`).
+- Alt text is covered by the media-accessibility skill, but note if images lack title attributes or captions that could improve search context.
+
+### Content Depth
+- Flag very short posts (under 300 words) — they rarely rank well for informational queries.
+- This is a soft guideline. Some content (announcements, updates) is naturally short.
+
+## How to Give Feedback
+
+- Don't use SEO jargon. Say "help people find this in search" not "optimize your SERP ranking."
+- Be specific about what to change. "Add a link to your pricing page in this paragraph" not "add internal links."
+- Keep notes under 50 words.
+- Prioritize: title/H1 issues > heading hierarchy > missing links > slug issues.
+
+## Examples of Good Notes
+
+> "Your title is 78 characters — search engines will truncate it. Try: 'Best Hiking Trails in Colorado' (30 chars) to show the full title in results."
+
+> "No internal links in this post. Consider linking 'our support team' to your contact page."
+
+> "Headings jump from H2 to H4. Add an H3 under 'Getting Started' to help search engines understand the structure."

--- a/claude-cowork/content-coach/.claude-plugin/plugin.json
+++ b/claude-cowork/content-coach/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "content-coach",
+  "name": "content-coach-cowork",
   "version": "0.1.0",
   "description": "AI-powered content reviewer that analyzes WordPress posts across four pillars — readability, search visibility, content guidelines, and media accessibility — and delivers actionable feedback as block notes directly in the editor.",
   "author": {

--- a/claude-cowork/content-coach/.claude-plugin/plugin.json
+++ b/claude-cowork/content-coach/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "content-coach",
+  "version": "0.1.0",
+  "description": "AI-powered content reviewer that analyzes WordPress posts across four pillars — readability, search visibility, content guidelines, and media accessibility — and delivers actionable feedback as block notes directly in the editor.",
+  "author": {
+    "name": "Automattic"
+  }
+}

--- a/claude-cowork/content-coach/CONNECTORS.md
+++ b/claude-cowork/content-coach/CONNECTORS.md
@@ -1,0 +1,88 @@
+# Connectors
+
+## Required: WordPress.com MCP Server
+
+This plugin requires the `wpcom-mcp-content-authoring` tool from the WordPress.com MCP server. It provides both content fetching and block notes operations via the STRAP pattern (Single Tool, Resource.Action, Params).
+
+### Operations Used
+
+| Operation | Purpose |
+|---|---|
+| `posts.get` | Fetch post content (title, raw block markup, rendered HTML) with `context=edit` |
+| `block-notes.list` | List blocks with their noteIds, and existing notes as threaded trees |
+| `block-notes.create` | Create a new note on a block (with `block_index` to associate it) |
+| `block-notes.reply` | Reply to an existing note thread on a block |
+
+### STRAP Actions
+
+- **`list`** — Discover all available operations
+- **`describe`** — Get the parameter schema for a specific operation
+- **`execute`** — Run an operation with params
+
+### Tool Call Examples
+
+**List notes and block map (read-only, no confirmation needed):**
+```json
+{
+  "wpcom_site": "yoursite.wordpress.com",
+  "action": "execute",
+  "operation": "block-notes.list",
+  "params": {
+    "post_id": 123
+  }
+}
+```
+
+**Create a note (mutative — requires `user_confirmed`):**
+```json
+{
+  "wpcom_site": "yoursite.wordpress.com",
+  "action": "execute",
+  "operation": "block-notes.create",
+  "params": {
+    "post_id": 123,
+    "content": "Consider splitting this sentence for readability.",
+    "block_index": 2,
+    "user_confirmed": "yes"
+  }
+}
+```
+
+**Reply to a note (mutative — requires `user_confirmed`):**
+```json
+{
+  "wpcom_site": "yoursite.wordpress.com",
+  "action": "execute",
+  "operation": "block-notes.reply",
+  "params": {
+    "post_id": 123,
+    "parent_id": 456,
+    "content": "This has been addressed.",
+    "user_confirmed": "yes"
+  }
+}
+```
+
+### Safety Policy
+
+The content-authoring tool enforces a safety policy on mutative operations (create, reply). You must:
+1. Describe what you plan to do to the user
+2. Get their confirmation
+3. Include `user_confirmed` with their response in `params`
+
+Read-only operations (`block-notes.list`, `posts.get`) are exempt.
+
+### Setup
+
+Ensure `wpcom-mcp-content-authoring` is enabled in your WordPress.com MCP settings.
+
+## Self-Contained Capabilities
+
+These features do not require external services:
+
+| Capability | Implementation |
+|---|---|
+| Readability analysis | Claude's language analysis |
+| SEO evaluation | Claude's knowledge of search best practices |
+| Content guidelines checks | Pattern matching against skill rules |
+| Media accessibility review | Block markup inspection |

--- a/claude-cowork/content-coach/README.md
+++ b/claude-cowork/content-coach/README.md
@@ -1,0 +1,57 @@
+# Content Coach Plugin
+
+An AI-powered content reviewer that analyzes WordPress posts and delivers actionable feedback as block notes directly in the editor.
+
+## Requirements
+
+- A WordPress.com site with the block notes feature enabled
+- The WordPress.com MCP server with `wpcom-mcp-content-authoring` enabled
+
+## Setup
+
+### Claude Cowork
+
+1. Upload the plugin ZIP via **Settings > Plugins**, or install from the marketplace.
+2. Ensure `wpcom-mcp-content-authoring` is enabled in your MCP settings.
+
+### Claude Code
+
+```bash
+claude --plugin-dir ./claude-cowork/content-coach
+```
+
+## Usage
+
+```
+/review-content <post-id>
+```
+
+Claude will:
+1. Fetch the post content and block map in parallel
+2. Analyze content across four quality pillars
+3. Ask for your confirmation before leaving notes
+4. Leave 3–8 concise, actionable block notes in the editor
+5. Summarize the findings in chat
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/review-content` | Review a WordPress post across four quality pillars and leave feedback as block notes |
+
+## Skills
+
+| Skill | What It Checks |
+|---|---|
+| `readability` | Sentence/paragraph length, passive voice, word complexity, heading clarity |
+| `search-visibility` | Title/H1, heading hierarchy, meta descriptions, internal links, URL slugs |
+| `content-guidelines` | Tone consistency, point of view, filler language, unsourced claims |
+| `media-accessibility` | Alt text, link text, heading structure, content accessibility |
+
+## How It Works
+
+1. Run `/review-content <post-id>`
+2. The plugin fetches the post content via `posts.get` and the block map + notes via `block-notes.list` — both through the `wpcom-mcp-content-authoring` tool
+3. Claude analyzes the content across all four pillars using the skill knowledge bases
+4. After showing you a summary and getting your confirmation, feedback is delivered as block notes
+5. The author sees the notes in the WordPress editor, highlighted on the relevant blocks

--- a/claude-cowork/content-coach/README.md
+++ b/claude-cowork/content-coach/README.md
@@ -14,12 +14,6 @@ An AI-powered content reviewer that analyzes WordPress posts and delivers action
 1. Upload the plugin ZIP via **Settings > Plugins**, or install from the marketplace.
 2. Ensure `wpcom-mcp-content-authoring` is enabled in your MCP settings.
 
-### Claude Code
-
-```bash
-claude --plugin-dir ./claude-cowork/content-coach
-```
-
 ## Usage
 
 ```

--- a/claude-cowork/content-coach/commands/review-content.md
+++ b/claude-cowork/content-coach/commands/review-content.md
@@ -1,0 +1,102 @@
+---
+description: Review a WordPress post and leave actionable feedback as block notes
+argument-hint: "<post ID>"
+---
+
+# Review Content
+
+> This command uses the `readability`, `search-visibility`, `content-guidelines`, and `media-accessibility` skills.
+
+Review a WordPress post across four quality pillars and deliver feedback as block notes that appear directly in the editor.
+
+## Trigger
+
+User runs `/review-content` with a post ID, or asks to review/coach/check a WordPress post.
+
+## Workflow
+
+### Step 1: Fetch Content and Notes
+
+Make these two calls in parallel using `wpcom-mcp-content-authoring`:
+
+1. **`posts.get`** with `context=edit` — returns the post content (title, raw block markup, rendered HTML) for analysis.
+2. **`block-notes.list`** with `post_id` — returns:
+   - A **block map** showing each top-level block's index, type, noteId, and content preview
+   - All existing **notes** as threaded trees
+
+From these two responses you have everything needed: the content to review and the note state of every block.
+
+- If notes already exist, read them. Do not duplicate feedback that's already been given.
+- If a previous note raised an issue that hasn't been addressed, you may reply to that thread — but don't repeat the same point.
+
+### Step 2: Analyze the Content
+
+Work through each pillar systematically. Identify the **highest-impact issues only** — do not flag everything. A useful review has 3–8 notes total, not 20.
+
+#### Pillar 1: Readability
+Apply the `readability` skill. Focus on:
+- Sentences over 25 words
+- Paragraphs over 4 sentences
+- Passive voice (only the most impactful instances)
+- Jargon with simpler alternatives
+
+#### Pillar 2: Search Visibility
+Apply the `search-visibility` skill. Focus on:
+- Title/H1 issues (missing, too long, generic)
+- Heading hierarchy problems (skipped levels)
+- Missing internal links
+- Slug quality
+
+#### Pillar 3: Content Guidelines
+Apply the `content-guidelines` skill. Focus on:
+- Tone inconsistencies (the biggest shifts only)
+- Unsubstantiated claims
+- Filler language (only the most egregious)
+
+#### Pillar 4: Media & Accessibility
+Apply the `media-accessibility` skill. Focus on:
+- Missing alt text on images (highest priority)
+- Poor link text ("click here")
+- Missing headings in long content
+
+### Step 3: Ask for Confirmation
+
+Before leaving any notes, tell the user:
+- How many notes you plan to leave
+- A brief summary of the issues found across each pillar
+
+Wait for the user to confirm before proceeding. Their confirmation response will be used as the `user_confirmed` value for each note operation.
+
+### Step 4: Leave Notes
+
+After the user confirms, leave the notes. For each issue:
+
+1. **Determine which block** the feedback applies to using the block map from Step 1.
+
+2. **Choose the right operation** on `wpcom-mcp-content-authoring`:
+   - Block has a `noteId` → use `block-notes.reply` with `parent_id` set to that noteId
+   - Block has no `noteId` → use `block-notes.create` with `block_index`
+
+3. **Include `user_confirmed`** in `params` with the user's confirmation response. This is required by the safety policy for all create/reply operations.
+
+4. **Write the note.** Follow these rules strictly:
+   - **50 words or fewer.** The block notes UI has limited space.
+   - **Do NOT mention block index, block type, or position.** The UI highlights the block — the reader knows which block it's on.
+   - **Be direct and actionable.** Say what to change and why. Don't describe what you observed.
+   - **Quote the specific text** when suggesting a rewrite.
+   - **One note per block.** If a block has multiple issues, combine the most important one into a single note.
+
+### Step 5: Summarize
+
+After leaving all notes, give the user a brief summary in chat (not as a block note):
+- How many notes you left
+- Which pillars had the most issues
+- The single most impactful change they could make
+
+## Constraints
+
+- **Do NOT edit the post content.** You are a reviewer, not an editor. Leave suggestions as notes.
+- **3–8 notes maximum** for a typical post. More than that overwhelms the author.
+- **Skip blocks that are fine.** Not every block needs a note. No news is good news.
+- **Don't be sycophantic.** Don't leave notes that say "Great paragraph!" — only leave notes that suggest improvements.
+- **Author name:** Use the default (authenticated user). Only pass `author_name` if the user requests a custom name.

--- a/claude-cowork/content-coach/commands/review-content.md
+++ b/claude-cowork/content-coach/commands/review-content.md
@@ -1,6 +1,6 @@
 ---
 description: Review a WordPress post and leave actionable feedback as block notes
-argument-hint: "<post ID>"
+argument-hint: "<post ID> [site URL]"
 ---
 
 # Review Content
@@ -11,9 +11,17 @@ Review a WordPress post across four quality pillars and deliver feedback as bloc
 
 ## Trigger
 
-User runs `/review-content` with a post ID, or asks to review/coach/check a WordPress post.
+User runs `/review-content` with a post ID (and optionally a site URL), or asks to review/coach/check a WordPress post.
 
 ## Workflow
+
+### Step 0: Resolve the Site
+
+Every MCP call requires a `wpcom_site` parameter. Determine the site using the first match:
+
+1. **Provided in the command** — e.g. `/review-content 123 mysite.wordpress.com`
+2. **Known from conversation context** — the user mentioned or used a site earlier
+3. **Ask the user** — if neither of the above, ask which site the post belongs to
 
 ### Step 1: Fetch Content and Notes
 

--- a/claude-cowork/content-coach/skills/content-guidelines/SKILL.md
+++ b/claude-cowork/content-coach/skills/content-guidelines/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: content-guidelines
+description: Check content against brand voice, tone consistency, and editorial standards. Use when reviewing content for professionalism and brand alignment.
+---
+
+# Content Guidelines Skill
+
+Ensure content maintains a consistent, professional voice and follows editorial best practices. This skill covers what the author *says* and *how* they say it.
+
+## What to Check
+
+### Tone Consistency
+- The tone should be consistent throughout the entire post.
+- Flag abrupt shifts — e.g., casual opening ("Hey folks!") followed by formal body ("It is imperative to note...").
+- Common inconsistency: lyrical/creative introductions followed by dry, factual body copy. The reader expects the same voice throughout.
+- Note which tone the majority of the post uses, and flag the outlier sections.
+
+### Point of View
+- Flag inconsistent POV switches within a post.
+- "We recommend..." then "You should..." then "One might consider..." — pick one and stick with it.
+- Second person ("you") is usually best for instructional content.
+- First person plural ("we") works for company blogs.
+
+### Filler and Weak Language
+- Flag hedging words that weaken the message: "very", "really", "quite", "somewhat", "fairly", "rather", "just".
+- Flag empty intensifiers: "extremely important", "absolutely essential" — if it's important, show why.
+- Flag clichés: "at the end of the day", "it goes without saying", "in today's world", "game-changer".
+
+### Repetition
+- Flag the same word or phrase used repeatedly in close proximity.
+- Flag repeated sentence structures (three sentences in a row starting with "This...").
+- Suggest varied alternatives.
+
+### Accuracy and Claims
+- Flag unsubstantiated claims: "studies show", "research proves", "experts agree" — without a source or link.
+- Flag superlatives without evidence: "the best", "the fastest", "the most popular".
+- Suggest adding a source link or softening to "one of the best" if no source is available.
+
+### Formatting Consistency
+- Flag inconsistent list formatting (some items end with periods, others don't).
+- Flag inconsistent capitalization in headings (some title case, some sentence case).
+- Flag inconsistent use of bold/italic for emphasis.
+
+## How to Give Feedback
+
+- Don't lecture about writing rules. Just suggest the fix.
+- Quote the specific phrase and offer a rewrite.
+- Keep notes under 50 words.
+- Tone issues are sensitive — frame feedback as consistency, not criticism of the author's voice.
+
+## Examples of Good Notes
+
+> "Tone shifts here from casual ('super easy') to formal ('it is recommended'). Match the casual voice used in earlier paragraphs: 'we recommend' keeps it consistent."
+
+> "'Very unique' — unique is absolute, no modifier needed. Just 'unique' or find a more specific adjective."
+
+> "'Studies show this improves engagement.' Which studies? Add a link or soften to 'this can improve engagement.'"

--- a/claude-cowork/content-coach/skills/media-accessibility/SKILL.md
+++ b/claude-cowork/content-coach/skills/media-accessibility/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: media-accessibility
+description: Review images, media, and visual elements for accessibility compliance and quality. Use when checking alt text, captions, and media best practices.
+---
+
+# Media & Accessibility Skill
+
+Ensure all media elements are accessible, properly described, and enhance the content rather than just decorating it.
+
+## What to Check
+
+### Alt Text
+- Every image block MUST have alt text. Flag any `core/image` block with empty or missing alt.
+- Alt text should describe what the image *shows*, not what it *is*.
+  - Bad: "image1.jpg", "photo", "screenshot"
+  - Bad: "Image of a person" (too generic)
+  - Good: "A hiker standing at the edge of a cliff overlooking a valley at sunrise"
+- Decorative images (spacers, dividers, background textures) should have empty alt (`alt=""`), not missing alt. But in practice, most images in post content are not decorative.
+- Flag alt text that starts with "Image of..." or "Photo of..." — screen readers already announce it as an image.
+- Flag excessively long alt text (over 125 characters). Keep it concise.
+
+### Image Quality Signals
+- Flag images with generic file names: `IMG_4532.jpg`, `screenshot-2024.png`, `image.png`.
+- Suggest descriptive file names that match the content.
+- Flag if a post has no images at all — for most content types, at least one image improves engagement.
+
+### Captions
+- Captions are optional but valuable. They're among the most-read text on a page.
+- Don't flag missing captions as an error — suggest them as an enhancement for key images.
+- Flag captions that just repeat the alt text. They should add context the alt text doesn't provide.
+
+### Heading Accessibility
+- Headings should not be empty.
+- Heading blocks used purely for visual styling (making text big/bold) without semantic meaning is an accessibility issue.
+- Content should be readable in heading order — if you read just the headings top to bottom, they should outline the post.
+
+### Link Accessibility
+- Flag links with text like "click here", "read more", "this link", "here". Screen readers often navigate by link text alone.
+- Good link text describes the destination: "read our pricing guide" not "click here."
+- Flag links that open in new tabs without indicating it (though this is hard to detect from markup alone — note as a general guideline).
+
+### Color and Contrast
+- Cannot be checked from markup alone, but flag cases where the author relies on color to convey meaning (e.g., "the items in red are required").
+- Suggest adding text labels alongside color indicators.
+
+### Content Structure
+- Flag very long posts with no headings — screen reader users rely on headings to navigate.
+- Flag content that uses bold text as a pseudo-heading instead of proper heading blocks.
+
+## How to Give Feedback
+
+- Frame accessibility feedback as helping *all* readers, not just compliance.
+- Be specific: "Add alt text describing what this chart shows" not "missing alt text."
+- Keep notes under 50 words.
+- Prioritize: missing alt text > heading issues > link text > everything else.
+
+## Examples of Good Notes
+
+> "Missing alt text. Describe what this image shows — e.g., 'Bar chart comparing monthly sales for Q1 2024 across three product lines.'"
+
+> "Link text 'click here' doesn't describe the destination. Try: 'view our return policy' so it makes sense out of context."
+
+> "No headings in 800+ words of content. Add H2s to break this into scannable sections — readers and screen readers both benefit."

--- a/claude-cowork/content-coach/skills/readability/SKILL.md
+++ b/claude-cowork/content-coach/skills/readability/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: readability
+description: Analyze text readability and suggest improvements to sentence structure, paragraph length, word complexity, and voice. Use when reviewing content for reader experience.
+---
+
+# Readability Skill
+
+Evaluate and improve how easy content is to read and understand. Poor readability increases bounce rates and reduces engagement.
+
+## What to Check
+
+### Sentence Length
+- Flag sentences over 25 words. They're hard to parse on screens.
+- Suggest splitting or simplifying — don't just say "too long."
+- One idea per sentence. If a sentence uses "and" or "but" to join two independent thoughts, it should probably be two sentences.
+
+### Paragraph Length
+- Flag paragraphs over 4 sentences or ~80 words.
+- Web readers scan. Dense walls of text get skipped.
+- Suggest logical break points when recommending a split.
+
+### Passive Voice
+- Flag passive constructions ("was written by", "has been updated", "will be reviewed").
+- Suggest the active alternative: who does the action?
+- Exception: passive is fine when the actor is unknown or irrelevant ("The server was restarted at 3am").
+
+### Word Complexity
+- Flag jargon, technical terms, or uncommon words that have simpler alternatives.
+- "utilize" → "use", "commence" → "start", "facilitate" → "help", "leverage" → "use".
+- Exception: domain-specific terms that the target audience expects (don't simplify "API" for a developer audience).
+
+### Transition and Flow
+- Flag abrupt topic changes between consecutive blocks.
+- Look for missing transition words or phrases between paragraphs.
+- Each paragraph should connect logically to the previous one.
+
+### Heading Clarity
+- Headings should tell the reader what the section contains.
+- Flag vague headings like "Overview", "Introduction", "More Info".
+- Good headings are specific: "How to set up email forwarding" not "Email Setup".
+
+## How to Give Feedback
+
+- Be specific. Quote the problematic phrase and suggest a rewrite.
+- Keep notes under 50 words. The block notes UI is small.
+- Focus on the highest-impact issues first. Don't flag every long sentence — pick the worst ones.
+- If a block has multiple readability issues, combine them into one note with the most important fix.
+
+## Examples of Good Notes
+
+> "Consider splitting this into two sentences at 'however.' The current 32-word sentence is hard to follow on mobile."
+
+> "Passive voice: 'was created by the team' → 'the team created'. Makes the action clearer."
+
+> "This paragraph covers pricing, features, and support. Split at the support section for easier scanning."

--- a/claude-cowork/content-coach/skills/search-visibility/SKILL.md
+++ b/claude-cowork/content-coach/skills/search-visibility/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: search-visibility
+description: Evaluate on-page SEO factors and suggest improvements to help content get found in search. Use when reviewing content for search engine visibility.
+---
+
+# Search Visibility Skill
+
+Help content rank better in search results without requiring SEO expertise from the author. Focus on practical, high-impact improvements.
+
+## What to Check
+
+### Title / H1
+- The post should have exactly one H1 (usually the post title).
+- The H1 should include the primary topic/keyword naturally.
+- Flag if the H1 is missing, duplicated, or generic ("Untitled", "New Post").
+- Keep titles under 60 characters to avoid truncation in search results.
+
+### Heading Hierarchy
+- Headings should follow a logical order: H1 → H2 → H3. No skipping levels.
+- Flag H3 that appears before any H2, or H4 without a parent H3.
+- Headings help search engines understand content structure.
+
+### Meta Description (if available)
+- Should be 120–160 characters.
+- Should summarize the page content and include the primary topic.
+- Should be compelling — it's the "ad copy" in search results.
+- Flag if missing or if it's just the first sentence of the post repeated.
+
+### Internal Links
+- Flag posts with zero internal links. Every post should link to at least one other page on the site.
+- Links help search engines discover and understand related content.
+- Suggest specific linking opportunities based on the content topic.
+
+### URL / Slug
+- Slugs should be short, descriptive, and include the primary topic.
+- Flag slugs that are auto-generated gibberish, excessively long, or include dates/IDs unnecessarily.
+- Good: `/best-hiking-trails-colorado` Bad: `/post-12847` or `/2024/01/15/the-complete-and-comprehensive-guide-to-all-hiking-trails`
+
+### Image SEO
+- Images should have descriptive file names (not `IMG_4532.jpg`).
+- Alt text is covered by the media-accessibility skill, but note if images lack title attributes or captions that could improve search context.
+
+### Content Depth
+- Flag very short posts (under 300 words) — they rarely rank well for informational queries.
+- This is a soft guideline. Some content (announcements, updates) is naturally short.
+
+## How to Give Feedback
+
+- Don't use SEO jargon. Say "help people find this in search" not "optimize your SERP ranking."
+- Be specific about what to change. "Add a link to your pricing page in this paragraph" not "add internal links."
+- Keep notes under 50 words.
+- Prioritize: title/H1 issues > heading hierarchy > missing links > slug issues.
+
+## Examples of Good Notes
+
+> "Your title is 78 characters — search engines will truncate it. Try: 'Best Hiking Trails in Colorado' (30 chars) to show the full title in results."
+
+> "No internal links in this post. Consider linking 'our support team' to your contact page."
+
+> "Headings jump from H2 to H4. Add an H3 under 'Getting Started' to help search engines understand the structure."


### PR DESCRIPTION
## Summary
- Adds **content coach** plugin — an AI-powered content reviewer that analyzes WordPress posts across four pillars (readability, search visibility, content guidelines, media accessibility) and delivers feedback as block notes in the editor
- Includes both **Claude Code** (`claude-code/content-coach/`) and **Claude Cowork/Desktop** (`claude-cowork/content-coach/`) versions with platform-specific MCP connector references (this needs specific MCP tooling that may currently be a work in progress `wpcom-206158` )
- Registers both plugins in the marketplace (`content-coach-code` and `content-coach`)

## Test plan
- [ ] Install the Claude Code plugin via `claude --plugin-dir ./claude-code/content-coach` and run `/review-content <post-id>` against a WordPress.com site with block notes enabled
- [ ] Install the Claude Cowork plugin in Claude Desktop and run `/review-content <post-id>` against the same site
- [ ] Verify block notes appear in the WordPress editor on the correct blocks
- [ ] Confirm the 4 skill pillars (readability, search visibility, content guidelines, media accessibility) are applied during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)